### PR TITLE
fix: Fix issues in coco format dumps

### DIFF
--- a/datumaro/datumaro/plugins/coco_format/converter.py
+++ b/datumaro/datumaro/plugins/coco_format/converter.py
@@ -294,7 +294,7 @@ class _InstancesConverter(_TaskConverter):
             area = mask_utils.area(rles)
         else:
             x, y, w, h = bbox
-            segmentation = [[x, y, x + w, y, x + w, y + h, x, y + h]]
+            segmentation = []
             area = w * h
 
         elem = {
@@ -514,7 +514,7 @@ class _Converter:
         filename += CocoPath.IMAGE_EXT
         path = osp.join(self._images_dir, filename)
         save_image(path, image)
-        return path
+        return filename
 
     def convert(self):
         self._make_dirs()


### PR DESCRIPTION
This fixes two issues:

1. The segmentation data being incorrect in some cases. This has been [fixed in upstream](https://github.com/openvinotoolkit/datumaro/blob/4b86aa4b7e42629f78a369849f6d923010a6138c/datumaro/plugins/coco_format/converter.py#L304) in latest version.
2. The data in COCO JSON including full path to images - instead it now only contains file names. I am not sure if this has been fixed in upstream in latest version.

Since these changes are in a plugin and one issue is already addressed in the latest version, I think it is ok to make the changes directly in this as opposed to creating a new plugin and overriding the code. However we do need to at least keep track of number 2 when we are not sure if that is addressed in the latest version. I am open to other ideas.